### PR TITLE
add before move and after move event

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,12 @@ Only the first parameter is required.
 
 # Events
 The mixin emits events on the loopback Event bus for certain operations.
-- `lbTree.add.success` when a node was added. Returns the new node 
-* `lbTree.move.childrenFound` During the move when we have found all the children. Return the children
-* `lbTree.move.parent` During the move we have the parent. Returns the parent
-* `lbTree.move.newPath` The new path after the move ended
+- `lbTree.add.success` when a node was added. Returns the new node
+* `lbTree.move.before` Just before start the moving operation. Return the previous parent, the new parent and the node.
+* `lbTree.move.after` After the moving operation. Return the previous parent, the new parent and the node.
+* `lbTree.move.childrenFound` During the move when we have found all the children. Return the children.
+* `lbTree.move.parent` During the move we have the parent. Returns the parent.
+* `lbTree.move.newPath` The new path after the move ended. Returns the node.
 * `lbTree.delete` Node deleted. Returns {success : true/false}
 * `lbTree.saveJsTree` When a JSTree operations is done. Returns the tree
 

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function Tree(Model, config) {
     };
 
     Model.moveNode = function (node, newParent, callback) {
+        console.log("AAAAAAAAAAAAAAAA");
         /*
          * 1. locate the node
          * 2. locate the parent
@@ -112,9 +113,13 @@ function Tree(Model, config) {
         };
 
         var _this = this;
-
+        var moveEventData={};
         return Promise.props(tasks)
             .then(function (results) {
+                moveEventData.oldParent=results.child.parent;
+                moveEventData.node=results.child;
+                moveEventData.newParent=results.parent.id;
+                Model.emit('lbTree.move.before', moveEventData);
                 results.child.parent = results.parent.id;
                 results.child.ancestors = results.parent.ancestors;
                 results.child.ancestors.push(results.parent.id);
@@ -122,6 +127,7 @@ function Tree(Model, config) {
             })
             .then(function (results) {
                 //find the children
+                console.log("find the children");
                 return Model.find({where: {ancestors: results.child.id}})
                     .then(function (children) {
                         if (children.length === 0) {
@@ -138,6 +144,7 @@ function Tree(Model, config) {
 
                         return Promise.all(tasks)
                             .then(function () {
+                                console.log("parent");
                                 Model.emit('lbTree.move.parent', results);
                                 return results;
                             });
@@ -148,6 +155,7 @@ function Tree(Model, config) {
                     .save()
                     .then(function (updatedItem) {
                         Model.emit('lbTree.move.newPath', updatedItem);
+                        Model.emit('lbTree.move.after', moveEventData);
                         return updatedItem;
                     });
             });


### PR DESCRIPTION
before move and after move event added, Both event return the old parent id, the new parent id and the actual node.

the move.after event is emitted just before the newPath event, i kept them separate because logically have different meaning and in my opinion have both allow more flexibility (based on application needed)
